### PR TITLE
Conditional includes OS X

### DIFF
--- a/cl/buffer.go
+++ b/cl/buffer.go
@@ -7,7 +7,11 @@ package cl
 #cgo !darwin LDFLAGS: -lOpenCL
 #cgo darwin LDFLAGS: -framework OpenCL
 
+#ifdef __APPLE__
+#include "OpenCL/opencl.h"
+#else
 #include "CL/opencl.h"
+#endif
 */
 import "C"
 

--- a/cl/buffer12.go
+++ b/cl/buffer12.go
@@ -7,8 +7,12 @@ package cl
 #cgo !darwin LDFLAGS: -lOpenCL
 #cgo darwin LDFLAGS: -framework OpenCL
 
+#ifdef __APPLE__
+#include "OpenCL/opencl.h"
+#else
 #include "CL/opencl.h"
-*/
+#endif
+ */
 import "C"
 import "unsafe"
 

--- a/cl/cl.go
+++ b/cl/cl.go
@@ -7,8 +7,12 @@ package cl
 #cgo !darwin LDFLAGS: -lOpenCL
 #cgo darwin LDFLAGS: -framework OpenCL
 
+#ifdef __APPLE__
+#include "OpenCL/opencl.h"
+#else
 #include "CL/opencl.h"
-*/
+#endif
+ */
 import "C"
 
 import "math"

--- a/cl/context.go
+++ b/cl/context.go
@@ -7,7 +7,11 @@ package cl
 #cgo !darwin LDFLAGS: -lOpenCL
 #cgo darwin LDFLAGS: -framework OpenCL
 
+#ifdef __APPLE__
+#include "OpenCL/opencl.h"
+#else
 #include "CL/opencl.h"
+#endif
 
 extern void go_ctx_notify(char *errinfo, void *private_info, int cb, void *user_data);
 static void CL_CALLBACK c_ctx_notify(const char *errinfo, const void *private_info, size_t cb, void *user_data) {

--- a/cl/device.go
+++ b/cl/device.go
@@ -7,8 +7,12 @@ package cl
 #cgo !darwin LDFLAGS: -lOpenCL
 #cgo darwin LDFLAGS: -framework OpenCL
 
+#ifdef __APPLE__
+#include "OpenCL/opencl.h"
+#else
 #include "CL/opencl.h"
-*/
+#endif
+ */
 import "C"
 import "unsafe"
 

--- a/cl/device12.go
+++ b/cl/device12.go
@@ -7,8 +7,12 @@ package cl
 #cgo !darwin LDFLAGS: -lOpenCL
 #cgo darwin LDFLAGS: -framework OpenCL
 
+#ifdef __APPLE__
+#include "OpenCL/opencl.h"
+#else
 #include "CL/opencl.h"
-*/
+#endif
+ */
 import "C"
 
 ///////////////////////////////////////////////

--- a/cl/event.go
+++ b/cl/event.go
@@ -7,7 +7,11 @@ package cl
 #cgo !darwin LDFLAGS: -lOpenCL
 #cgo darwin LDFLAGS: -framework OpenCL
 
+#ifdef __APPLE__
+#include "OpenCL/opencl.h"
+#else
 #include "CL/opencl.h"
+#endif
 
 extern void go_evt_notify(cl_event event, cl_int event_command_exec_status, void *user_data);
 static void CL_CALLBACK c_evt_notify(cl_event event, cl_int event_command_exec_status, void *user_data) {

--- a/cl/event11.go
+++ b/cl/event11.go
@@ -7,8 +7,13 @@ package cl
 #cgo !darwin LDFLAGS: -lOpenCL
 #cgo darwin LDFLAGS: -framework OpenCL
 
+#ifdef __APPLE__
+#include "OpenCL/opencl.h"
+#else
 #include "CL/opencl.h"
-*/
+#endif
+
+ */
 import "C"
 
 ///////////////////////////////////////////////

--- a/cl/event12.go
+++ b/cl/event12.go
@@ -7,8 +7,12 @@ package cl
 #cgo !darwin LDFLAGS: -lOpenCL
 #cgo darwin LDFLAGS: -framework OpenCL
 
+#ifdef __APPLE__
+#include "OpenCL/opencl.h"
+#else
 #include "CL/opencl.h"
-*/
+#endif
+ */
 import "C"
 
 ///////////////////////////////////////////////

--- a/cl/image.go
+++ b/cl/image.go
@@ -7,8 +7,12 @@ package cl
 #cgo !darwin LDFLAGS: -lOpenCL
 #cgo darwin LDFLAGS: -framework OpenCL
 
+#ifdef __APPLE__
+#include "OpenCL/opencl.h"
+#else
 #include "CL/opencl.h"
-*/
+#endif
+ */
 import "C"
 
 import (

--- a/cl/image11.go
+++ b/cl/image11.go
@@ -7,8 +7,12 @@ package cl
 #cgo !darwin LDFLAGS: -lOpenCL
 #cgo darwin LDFLAGS: -framework OpenCL
 
+#ifdef __APPLE__
+#include "OpenCL/opencl.h"
+#else
 #include "CL/opencl.h"
-*/
+#endif
+ */
 import "C"
 import "unsafe"
 

--- a/cl/image12.go
+++ b/cl/image12.go
@@ -7,8 +7,12 @@ package cl
 #cgo !darwin LDFLAGS: -lOpenCL
 #cgo darwin LDFLAGS: -framework OpenCL
 
+#ifdef __APPLE__
+#include "OpenCL/opencl.h"
+#else
 #include "CL/opencl.h"
-*/
+#endif
+ */
 import "C"
 import "unsafe"
 

--- a/cl/kernel.go
+++ b/cl/kernel.go
@@ -7,7 +7,11 @@ package cl
 #cgo !darwin LDFLAGS: -lOpenCL
 #cgo darwin LDFLAGS: -framework OpenCL
 
+#ifdef __APPLE__
+#include "OpenCL/opencl.h"
+#else
 #include "CL/opencl.h"
+#endif
 #include <string.h>
 #include <stdlib.h>
 */

--- a/cl/kernel12.go
+++ b/cl/kernel12.go
@@ -7,8 +7,12 @@ package cl
 #cgo !darwin LDFLAGS: -lOpenCL
 #cgo darwin LDFLAGS: -framework OpenCL
 
+#ifdef __APPLE__
+#include "OpenCL/opencl.h"
+#else
 #include "CL/opencl.h"
-*/
+#endif
+ */
 import "C"
 import "unsafe"
 

--- a/cl/kernel1x.go
+++ b/cl/kernel1x.go
@@ -7,7 +7,11 @@ package cl
 #cgo !darwin LDFLAGS: -lOpenCL
 #cgo darwin LDFLAGS: -framework OpenCL
 
+#ifdef __APPLE__
+#include "OpenCL/opencl.h"
+#else
 #include "CL/opencl.h"
+#endif
 */
 import "C"
 

--- a/cl/kernel20.go
+++ b/cl/kernel20.go
@@ -7,7 +7,11 @@ package cl
 #cgo !darwin LDFLAGS: -lOpenCL
 #cgo darwin LDFLAGS: -framework OpenCL
 
+#ifdef __APPLE__
+#include "OpenCL/opencl.h"
+#else
 #include "CL/opencl.h"
+#endif
 */
 import "C"
 

--- a/cl/memory.go
+++ b/cl/memory.go
@@ -7,8 +7,11 @@ package cl
 #cgo !darwin LDFLAGS: -lOpenCL
 #cgo darwin LDFLAGS: -framework OpenCL
 
+#ifdef __APPLE__
+#include "OpenCL/opencl.h"
+#else
 #include "CL/opencl.h"
-
+#endif
 extern void go_mem_notify(cl_mem memobj, void *user_data);
 static void CL_CALLBACK c_mem_notify(cl_mem memobj, void *user_data) {
 	go_mem_notify(memobj, user_data);

--- a/cl/memory12.go
+++ b/cl/memory12.go
@@ -7,7 +7,11 @@ package cl
 #cgo !darwin LDFLAGS: -lOpenCL
 #cgo darwin LDFLAGS: -framework OpenCL
 
+#ifdef __APPLE__
+#include "OpenCL/opencl.h"
+#else
 #include "CL/opencl.h"
+#endif
 */
 import "C"
 

--- a/cl/pipe20.go
+++ b/cl/pipe20.go
@@ -7,7 +7,11 @@ package cl
 #cgo !darwin LDFLAGS: -lOpenCL
 #cgo darwin LDFLAGS: -framework OpenCL
 
+#ifdef __APPLE__
+#include "OpenCL/opencl.h"
+#else
 #include "CL/opencl.h"
+#endif
 */
 import "C"
 

--- a/cl/platform.go
+++ b/cl/platform.go
@@ -7,7 +7,11 @@ package cl
 #cgo !darwin LDFLAGS: -lOpenCL
 #cgo darwin LDFLAGS: -framework OpenCL
 
+#ifdef __APPLE__
+#include "OpenCL/opencl.h"
+#else
 #include "CL/opencl.h"
+#endif
 */
 import "C"
 import "unsafe"

--- a/cl/program.go
+++ b/cl/program.go
@@ -7,7 +7,11 @@ package cl
 #cgo !darwin LDFLAGS: -lOpenCL
 #cgo darwin LDFLAGS: -framework OpenCL
 
+#ifdef __APPLE__
+#include "OpenCL/opencl.h"
+#else
 #include "CL/opencl.h"
+#endif
 #include <string.h>
 #include <stdlib.h>
 

--- a/cl/program11.go
+++ b/cl/program11.go
@@ -7,7 +7,11 @@ package cl
 #cgo !darwin LDFLAGS: -lOpenCL
 #cgo darwin LDFLAGS: -framework OpenCL
 
+#ifdef __APPLE__
+#include "OpenCL/opencl.h"
+#else
 #include "CL/opencl.h"
+#endif
 */
 import "C"
 

--- a/cl/program12.go
+++ b/cl/program12.go
@@ -7,7 +7,11 @@ package cl
 #cgo !darwin LDFLAGS: -lOpenCL
 #cgo darwin LDFLAGS: -framework OpenCL
 
+#ifdef __APPLE__
+#include "OpenCL/opencl.h"
+#else
 #include "CL/opencl.h"
+#endif
 #include <string.h>
 #include <stdlib.h>
 

--- a/cl/queue.go
+++ b/cl/queue.go
@@ -7,7 +7,11 @@ package cl
 #cgo !darwin LDFLAGS: -lOpenCL
 #cgo darwin LDFLAGS: -framework OpenCL
 
+#ifdef __APPLE__
+#include "OpenCL/opencl.h"
+#else
 #include "CL/opencl.h"
+#endif
 */
 import "C"
 

--- a/cl/queue1x.go
+++ b/cl/queue1x.go
@@ -7,7 +7,11 @@ package cl
 #cgo !darwin LDFLAGS: -lOpenCL
 #cgo darwin LDFLAGS: -framework OpenCL
 
+#ifdef __APPLE__
+#include "OpenCL/opencl.h"
+#else
 #include "CL/opencl.h"
+#endif
 */
 import "C"
 

--- a/cl/queue20.go
+++ b/cl/queue20.go
@@ -7,7 +7,11 @@ package cl
 #cgo !darwin LDFLAGS: -lOpenCL
 #cgo darwin LDFLAGS: -framework OpenCL
 
+#ifdef __APPLE__
+#include "OpenCL/opencl.h"
+#else
 #include "CL/opencl.h"
+#endif
 */
 import "C"
 

--- a/cl/sampler.go
+++ b/cl/sampler.go
@@ -7,7 +7,11 @@ package cl
 #cgo !darwin LDFLAGS: -lOpenCL
 #cgo darwin LDFLAGS: -framework OpenCL
 
+#ifdef __APPLE__
+#include "OpenCL/opencl.h"
+#else
 #include "CL/opencl.h"
+#endif
 */
 import "C"
 

--- a/cl/sampler1x.go
+++ b/cl/sampler1x.go
@@ -7,7 +7,11 @@ package cl
 #cgo !darwin LDFLAGS: -lOpenCL
 #cgo darwin LDFLAGS: -framework OpenCL
 
+#ifdef __APPLE__
+#include "OpenCL/opencl.h"
+#else
 #include "CL/opencl.h"
+#endif
 */
 import "C"
 

--- a/cl/sampler20.go
+++ b/cl/sampler20.go
@@ -7,7 +7,11 @@ package cl
 #cgo !darwin LDFLAGS: -lOpenCL
 #cgo darwin LDFLAGS: -framework OpenCL
 
+#ifdef __APPLE__
+#include "OpenCL/opencl.h"
+#else
 #include "CL/opencl.h"
+#endif
 */
 import "C"
 

--- a/cl/svm20.go
+++ b/cl/svm20.go
@@ -7,8 +7,11 @@ package cl
 #cgo !darwin LDFLAGS: -lOpenCL
 #cgo darwin LDFLAGS: -framework OpenCL
 
+#ifdef __APPLE__
+#include "OpenCL/opencl.h"
+#else
 #include "CL/opencl.h"
-
+#endif
 extern void go_svm_notify(cl_command_queue command_queue, cl_uint num_svm_pointers, void *svm_pointers[], void *user_data);
 static void CL_CALLBACK c_svm_notify(cl_command_queue command_queue, cl_uint num_svm_pointers, void *svm_pointers[], void *user_data) {
 	go_svm_notify(command_queue, num_svm_pointers, svm_pointers, user_data);


### PR DESCRIPTION
Under OS X the iOpenCL nclude files reside in a different sub-directory, an additional conditional include is needed to compile the cl package.